### PR TITLE
Add generic #[openapi(x_* = ...)] extension attribute

### DIFF
--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -836,6 +836,70 @@ fn extract_is_collapsed(attrs: &[Attribute]) -> bool {
     false
 }
 
+/// Collects generic OpenAPI vendor extensions declared with
+/// `#[openapi(x_name = value)]`, where the attribute name starts with `x_`.
+/// Supports bool, int, and string literal values; invalid lit types emit a
+/// compile error. Returns token streams that insert each pair into `s.extensions`
+/// at schema-build time.
+///
+/// Usage on a field:
+/// ```ignore
+/// #[openapi(x_fp_preserve_keys = true)]
+/// pub value: SomeType,
+/// ```
+///
+/// Emits `x_fp_preserve_keys: true` as a vendor extension on the property.
+fn extract_x_extensions(attrs: &[Attribute]) -> Vec<TokenStream2> {
+    let mut out = Vec::new();
+    let attrs = extract_openapi_attrs(attrs);
+    for attr in attrs.flat_map(|attr| attr.into_iter()) {
+        if let NestedMeta::Meta(Meta::NameValue(nv)) = attr {
+            let Some(ident) = nv.path.get_ident() else {
+                continue;
+            };
+            let name = ident.to_string();
+            if !name.starts_with("x_") {
+                continue;
+            }
+            let value_tokens = match &nv.lit {
+                Lit::Bool(b) => {
+                    let v = b.value;
+                    quote!(serde_json::Value::Bool(#v))
+                }
+                Lit::Int(i) => {
+                    let parsed = i.base10_parse::<i64>();
+                    match parsed {
+                        Ok(v) => quote!(serde_json::Value::Number(#v.into())),
+                        Err(_) => {
+                            emit_error!(
+                                nv.lit.span().unwrap(),
+                                format!("`#[{}({} = ...)]` expects an i64-parsable integer", SCHEMA_MACRO_ATTR, name),
+                            );
+                            continue;
+                        }
+                    }
+                }
+                Lit::Str(s) => {
+                    let v = s.value();
+                    quote!(serde_json::Value::String(#v.to_string()))
+                }
+                _ => {
+                    emit_error!(
+                        nv.lit.span().unwrap(),
+                        format!(
+                            "`#[{}({} = ...)]` only supports bool, int, or string values",
+                            SCHEMA_MACRO_ATTR, name
+                        ),
+                    );
+                    continue;
+                }
+            };
+            out.push(quote!(s.extensions.insert(#name.to_string(), #value_tokens);));
+        }
+    }
+    out
+}
+
 fn extract_priority(attrs: &[Attribute]) -> Option<u32> {
     let attrs = extract_openapi_attrs(attrs);
     for attr in attrs.flat_map(|attr| attr.into_iter()) {
@@ -1607,6 +1671,8 @@ fn extract_metadata(attrs: &[Attribute]) -> TokenStream2 {
         quote!()
     };
 
+    let x_extensions = extract_x_extensions(&attrs);
+
     let priority = if let Some(priority) = extract_priority(&attrs) {
         quote!(s.extensions.insert("x_fp_priority".to_string(), serde_json::Value::Number(#priority.into()));)
     } else {
@@ -1626,6 +1692,7 @@ fn extract_metadata(attrs: &[Attribute]) -> TokenStream2 {
         #docs
         #preview_gate
         #collapsed
+        #(#x_extensions)*
         #priority
         #example
     )


### PR DESCRIPTION
## Summary

Adds a generic way to declare arbitrary OpenAPI vendor extensions on schema properties via `#[openapi(x_* = ...)]` attributes on struct fields. The derive macro collects any `openapi` attribute whose name starts with `x_` and inserts it into `DefaultSchemaRaw.extensions`. The existing v2 → v3 conversion carries those through to the emitted spec.

Supported value types: `bool`, `i64`, `String` literals. Invalid literal types emit a compile error.

## Why

Footprint has been adding specific attributes one-at-a-time (`x_fp_preview_gate`, `x_fp_collapsed`, `x_fp_priority`) — each requires a fork patch. This generalizes the mechanism so any new `x_fp_*` extension works without touching paperclip.

Immediate use case: tagging fields that hold user-defined JSON so SDK clients know not to rename their keys (e.g. snake_case → camelCase). A follow-up consumer PR in the monorepo uses `#[openapi(x_fp_preserve_keys = true)]` on `OnboardingDataEntry.value` to fix a bug with user-authored Python `code_exec` node outputs being silently camelCased.

## Approach

Follows the shape of the existing attribute extractors:
- New `extract_x_extensions` walks `#[openapi(...)]` NameValue pairs, keeps those whose name starts with `x_`, and returns TokenStreams that insert `(name, value)` pairs into `s.extensions` at schema-build time.
- `extract_metadata` splices the resulting token streams alongside the existing specific extractors.
- The `x_` prefix gate keeps generic extensions from colliding with named attributes like `collapsed`, `priority`, `gated`, `required`, `optional`, `inline`, `debug`.

The existing specific attributes keep working unchanged; migrating them to this generic mechanism can happen in a follow-up.

## Usage

```rust
#[derive(Apiv2Schema, Serialize)]
pub struct OnboardingDataEntry {
    pub key: OnboardingDataKey,
    #[openapi(x_fp_preserve_keys = true)]
    pub value: PiiJsonValue,
}
```

Emits:

```json
"value": {
  "allOf": [{ "$ref": "#/components/schemas/PiiJsonValue" }, ...],
  "x_fp_preserve_keys": true
}
```

Also works for int/string:

```rust
#[openapi(x_fp_some_count = 42)]
#[openapi(x_fp_some_label = "hello")]
```

## Test plan

- [x] `cargo build -p paperclip-macros` — clean (one pre-existing dead_code warning on `MacroAttribute`, unrelated).
- [x] `cargo check --workspace` — clean.
- [x] End-to-end verified in the monorepo: paperclip emits the extension, the spec carries it, the frontend codegen harvests it, the runtime SDK respects it.
